### PR TITLE
[MERGE] [feat/login to main] Issue1 - Response Body의 accessToken 유무에 따른 분기 처리

### DIFF
--- a/app/src/main/java/com/example/android_repo_04/view/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/login/LoginActivity.kt
@@ -58,8 +58,13 @@ class LoginActivity : AppCompatActivity() {
     }
 
     private fun getUserCode() {
-        if (intent.data != null)
+        if (intent.data != null) {
             viewModel.requestToken(intent.data?.getQueryParameter(getString(R.string.code))!!)
+            binding.apply {
+                progressLoginLogin.visibility = View.VISIBLE
+                btnLoginLogin.visibility = View.INVISIBLE
+            }
+        }
     }
 
     private fun setOnClickListeners(){

--- a/app/src/main/java/com/example/android_repo_04/view/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/login/LoginActivity.kt
@@ -5,6 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import android.widget.Toast
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -31,7 +32,13 @@ class LoginActivity : AppCompatActivity() {
     }
 
     private val tokenObserver: (String) -> Unit = { token ->
-        if (token != "") {
+        if (token == "error") {
+            Toast.makeText(this, "앱의 상태 정보가 정확하지 않습니다. 개발자에게 문의 바랍니다.", Toast.LENGTH_SHORT).show()
+            binding.apply {
+                progressLoginLogin.visibility = View.INVISIBLE
+                btnLoginLogin.visibility = View.VISIBLE
+            }
+        } else if (token != "") {
             UserToken.accessToken = token
             startMainActivity()
         }

--- a/app/src/main/java/com/example/android_repo_04/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/android_repo_04/viewmodel/LoginViewModel.kt
@@ -19,10 +19,10 @@ class LoginViewModel(private val gitHubRepository: GitHubRepository) : ViewModel
     fun requestToken(code: String) {
         CoroutineScope(Dispatchers.IO).launch {
             gitHubRepository.requestToken(BuildConfig.CLIENT_ID, BuildConfig.CLIENT_SECRET, code) { response ->
-                if(response.isSuccessful){
+                if (response.isSuccessful && response.body()?.accessToken != null) {
                     _token.postValue(response.body()?.accessToken)
-                } else{
-                    //TODO 에러처리
+                } else {
+                    _token.postValue("error")
                 }
             }
         }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -34,4 +34,16 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.9" />
 
+    <ProgressBar
+        android:id="@+id/progress_login_login"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        style="?android:attr/progressBarStyleLarge"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.9"
+        android:visibility="invisible" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## access token 요청 시 생길 수 있는 오류
- client 권한 문제 : client id, client secret의 문제
- redirect uri 문제 : 딥링크 host 혹은 scheme 설정 문제
- 인증 code가 올바르지 않거나, 만료되었거나, 첫 번째 승인 요청에서 받은 것과 일치하지 않는 문제

> code 요청 시에 생기는 문제는 web page 상에서 문제가 생기는 경우이기 때문에, 앱에서 따로 감지할 수 없다고 여겼습니다.
> 그래서 access token 요청 시에 생기는 문제만 체크했습니다. 아래는 해당 내용 관련 공식 문서입니다.
> [Access Token Troubleshooting](https://docs.github.com/en/developers/apps/managing-oauth-apps/troubleshooting-oauth-app-access-token-request-errors)

## 오류가 생기면 나타나는 증상
- Response Body의 형태가 다릅니다. 올바른 요청 시 Response Body가 아래와 같은 형태입니다.
```
{
    "access_token":"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",
    "token_type":"bearer",
    "scope":""
}
```
- 잘못된 Token 요청 시 아래의 형태로 응답이 옵니다.
```
{
    "error":"incorrect_client_credentials",
    "error_description":"The client_id and/or client_secret passed are incorrect.",
    "error_uri":"https://docs.github.com/apps/managing-oauth-apps/troubleshooting-oauth-app-access-token-request-errors/#incorrect-client-credentials"
}
```
그래서 `AuthToken` data class에 `access_token` 변수가 `null`인지만 체크해주었습니다.
추가로 에러가 감지되면, _개발자에게 문의해달라_ 는 토스트 메시지를.... 😃 

## Progress Bar
특별한 설정 없이 기본 Circle형태 Progress Bar를 버튼과 교대로 show and hide 하도록 설정했습니다.