### PR TITLE
[MERGE] [feat/profile to main] Profile 화면 구현 완료

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,9 @@ android {
 
 dependencies {
 
+    //CircleImageView
+    implementation "de.hdodenhof:circleimageview:${circle_imageview_version}"
+
     //KotPref
     implementation "com.chibatching.kotpref:kotpref:${kotpref_version}"
 

--- a/app/src/main/java/com/example/android_repo_04/api/GitHubApiRepository.kt
+++ b/app/src/main/java/com/example/android_repo_04/api/GitHubApiRepository.kt
@@ -1,11 +1,23 @@
 package com.example.android_repo_04.api
 
 import com.example.android_repo_04.data.dto.issue.Issue
+import com.example.android_repo_04.data.dto.profile.Star
+import com.example.android_repo_04.data.dto.profile.User
 import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Header
 
 class GitHubApiRepository {
     suspend fun requestIssues(token: String, state: String, filter: String, callback: (Response<Issue>) -> Unit){
         callback(RetrofitFactory.createApiService()!!.requestIssues(token,state,filter))
+    }
+
+    suspend fun requestUser(token: String, callback: (Response<User>) -> Unit) {
+        callback(RetrofitFactory.createApiService()!!.requestUser(token))
+    }
+
+    suspend fun requestUserStarred(token: String, callback: (Response<List<Star>>) -> Unit) {
+        callback(RetrofitFactory.createApiService()!!.requestUserStarred(token))
     }
 
     companion object{

--- a/app/src/main/java/com/example/android_repo_04/api/GitHubApiService.kt
+++ b/app/src/main/java/com/example/android_repo_04/api/GitHubApiService.kt
@@ -1,6 +1,8 @@
 package com.example.android_repo_04.api
 
 import com.example.android_repo_04.data.dto.issue.Issue
+import com.example.android_repo_04.data.dto.profile.Star
+import com.example.android_repo_04.data.dto.profile.User
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -13,4 +15,14 @@ interface GitHubApiService {
         @Query("state") state: String,
         @Query("filter") filter: String
     ): Response<Issue>
+
+    @GET("user")
+    suspend fun requestUser(
+        @Header("Authorization") token: String
+    ): Response<User>
+
+    @GET("user/starred")
+    suspend fun requestUserStarred(
+        @Header("Authorization") token: String
+    ): Response<List<Star>>
 }

--- a/app/src/main/java/com/example/android_repo_04/data/dto/profile/Star.kt
+++ b/app/src/main/java/com/example/android_repo_04/data/dto/profile/Star.kt
@@ -1,0 +1,5 @@
+package com.example.android_repo_04.data.dto.profile
+
+data class Star(
+    val id: Long
+)

--- a/app/src/main/java/com/example/android_repo_04/data/dto/profile/User.kt
+++ b/app/src/main/java/com/example/android_repo_04/data/dto/profile/User.kt
@@ -1,0 +1,15 @@
+package com.example.android_repo_04.data.dto.profile
+
+data class User(
+    val avatar_url: String,
+    val bio: String,
+    val blog: String,
+    val email: String,
+    val followers: Int,
+    val following: Int,
+    val location: String,
+    val login: String,
+    val name: String,
+    val public_repos: Int,
+    val total_private_repos: Int,
+)

--- a/app/src/main/java/com/example/android_repo_04/view/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/profile/ProfileActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.lifecycle.ViewModelProvider
 import com.example.android_repo_04.R
 import com.example.android_repo_04.api.GitHubApiRepository
+import com.example.android_repo_04.data.db.UserToken
 import com.example.android_repo_04.databinding.ActivityProfileBinding
 import com.example.android_repo_04.viewmodel.ProfileViewModel
 import com.example.android_repo_04.viewmodel.ProfileViewModelFactory
@@ -20,11 +21,34 @@ class ProfileActivity : AppCompatActivity() {
         binding = ActivityProfileBinding.inflate(layoutInflater)
         setContentView(binding.root)
         initViewModel()
+        initBinding()
+        requestUser()
+        requestUserStarred()
+        setOnClickListeners()
     }
 
     private fun initViewModel() {
         viewModel = ViewModelProvider(this,
             ProfileViewModelFactory(GitHubApiRepository.getGitInstance()!!)
         )[ProfileViewModel::class.java]
+    }
+
+    private fun requestUser() {
+        viewModel.requestUser("token ${UserToken.accessToken}")
+    }
+
+    private fun requestUserStarred() {
+        viewModel.requestUserStarred("token ${UserToken.accessToken}")
+    }
+
+    private fun initBinding() {
+        binding.apply {
+            vm = viewModel
+            lifecycleOwner = this@ProfileActivity
+        }
+    }
+
+    private fun setOnClickListeners() {
+        binding.imgProfileBack.setOnClickListener { onBackPressed() }
     }
 }

--- a/app/src/main/java/com/example/android_repo_04/view/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/profile/ProfileActivity.kt
@@ -2,11 +2,29 @@ package com.example.android_repo_04.view.profile
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.lifecycle.ViewModelProvider
 import com.example.android_repo_04.R
+import com.example.android_repo_04.api.GitHubApiRepository
+import com.example.android_repo_04.databinding.ActivityProfileBinding
+import com.example.android_repo_04.viewmodel.ProfileViewModel
+import com.example.android_repo_04.viewmodel.ProfileViewModelFactory
 
 class ProfileActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityProfileBinding
+
+    private lateinit var viewModel: ProfileViewModel
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_profile)
+        binding = ActivityProfileBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        initViewModel()
+    }
+
+    private fun initViewModel() {
+        viewModel = ViewModelProvider(this,
+            ProfileViewModelFactory(GitHubApiRepository.getGitInstance()!!)
+        )[ProfileViewModel::class.java]
     }
 }

--- a/app/src/main/java/com/example/android_repo_04/view/profile/ProfileBindingAdapter.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/profile/ProfileBindingAdapter.kt
@@ -1,0 +1,46 @@
+package com.example.android_repo_04.view.profile
+
+import android.widget.TextView
+import androidx.databinding.BindingAdapter
+import com.bumptech.glide.Glide
+import de.hdodenhof.circleimageview.CircleImageView
+
+object ProfileBindingAdapter {
+    @JvmStatic
+    @BindingAdapter("profileImage")
+    fun setProfileImage(view: CircleImageView, url: String?){
+        Glide.with(view.context)
+            .load(url)
+            .into(view)
+    }
+
+    @JvmStatic
+    @BindingAdapter("locationText")
+    fun setLocationText(view: TextView, text: String?) {
+        if(text == null || text == "") {
+            view.text = "No Location"
+        } else {
+            view.text = text
+        }
+    }
+
+    @JvmStatic
+    @BindingAdapter("blogText")
+    fun setBlogText(view: TextView, text: String?) {
+        if(text == null || text == "") {
+            view.text = "No Blog"
+        } else {
+            view.text = text
+        }
+    }
+
+    @JvmStatic
+    @BindingAdapter("mailText")
+    fun setMailText(view: TextView, text: String?) {
+        if(text == null || text == "") {
+            view.text = "No Email"
+        } else {
+            view.text = text
+        }
+    }
+}

--- a/app/src/main/java/com/example/android_repo_04/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/android_repo_04/viewmodel/ProfileViewModel.kt
@@ -1,0 +1,46 @@
+package com.example.android_repo_04.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.android_repo_04.api.GitHubApiRepository
+import com.example.android_repo_04.data.dto.profile.User
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class ProfileViewModel(private val gitHubApiRepository: GitHubApiRepository): ViewModel() {
+
+    val user = MutableLiveData<User>()
+    val star = MutableLiveData<Int>()
+
+    fun requestUser(token: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            gitHubApiRepository.requestUser(token) { response ->
+                if(response.isSuccessful) {
+                    user.postValue(response.body())
+                }
+            }
+        }
+    }
+
+    fun requestUserStarred(token: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            gitHubApiRepository.requestUserStarred(token) { response ->
+                if(response.isSuccessful) {
+                    star.postValue(response.body()!!.size)
+                }
+            }
+        }
+    }
+}
+
+class ProfileViewModelFactory(private val gitHubApiRepository: GitHubApiRepository): ViewModelProvider.Factory {
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        if(modelClass.isAssignableFrom(ProfileViewModel::class.java)) {
+            return ProfileViewModel(gitHubApiRepository) as T
+        }
+        throw IllegalAccessException()
+    }
+}

--- a/app/src/main/java/com/example/android_repo_04/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/android_repo_04/viewmodel/ProfileViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.android_repo_04.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -1,282 +1,366 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/layout_profile_container"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@drawable/background_gradient"
-    tools:context=".view.profile.ProfileActivity">
+    xmlns:bind="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/layout_profile_toolbar"
-        android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
-        app:contentInsetStart="0dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+    <data>
 
-        <ImageView
-            android:id="@+id/img_profile_back"
-            android:layout_width="56dp"
-            android:layout_height="56dp"
-            android:layout_marginStart="12dp"
-            android:background="@drawable/icon_ripple_effect"
-            android:padding="16dp"
-            tools:src="@drawable/ic_back" />
-
-        <TextView
-            android:id="@+id/text_profile_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:text="@string/profile_title"
-            android:textColor="@color/white"
-            android:textSize="16sp" />
-    </androidx.appcompat.widget.Toolbar>
-
-    <ImageView
-        android:id="@+id/img_profile_profile"
-        android:layout_width="80dp"
-        android:layout_height="80dp"
-        android:layout_marginStart="24dp"
-        android:layout_marginTop="24dp"
-        android:background="@drawable/ic_user"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/layout_profile_toolbar" />
-
-    <TextView
-        android:id="@+id/text_profile_display_name"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:textColor="@color/white"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/img_profile_profile"
-        app:layout_constraintTop_toTopOf="@id/img_profile_profile"
-        tools:text="최광현" />
-
-    <TextView
-        android:id="@+id/text_profile_user_name"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:textColor="@color/grey"
-        android:textSize="16sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/text_profile_display_name"
-        app:layout_constraintTop_toBottomOf="@id/text_profile_display_name"
-        tools:text="kwangddang" />
-
-    <TextView
-        android:id="@+id/text_profile_bio"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:background="@drawable/background_round_navy"
-        android:ellipsize="end"
-        android:maxLines="2"
-        android:paddingHorizontal="12dp"
-        android:textColor="@color/grey"
-        android:textSize="16sp"
-        app:layout_constraintStart_toStartOf="@id/text_profile_display_name"
-        app:layout_constraintTop_toBottomOf="@id/text_profile_user_name"
-        tools:text="Android Developer" />
-
-    <View
-        android:id="@+id/view_profile_divider"
-        android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:layout_marginTop="16dp"
-        android:background="@color/navy"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/text_profile_bio" />
-
-    <ImageView
-        android:id="@+id/img_profile_location"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_location"
-        android:layout_marginStart="24dp"
-        android:layout_marginTop="18dp"
-        app:layout_constraintTop_toBottomOf="@id/view_profile_divider"
-        app:layout_constraintStart_toStartOf="parent"/>
-
-    <TextView
-        android:id="@+id/text_profile_location"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:textSize="16sp"
-        android:textColor="@color/white"
-        android:layout_marginStart="16dp"
-        app:layout_constraintStart_toEndOf="@id/img_profile_location"
-        app:layout_constraintTop_toTopOf="@id/img_profile_location"
-        app:layout_constraintBottom_toBottomOf="@id/img_profile_location"
-        tools:text="Seoul, Korea"/>
-
-    <ImageView
-        android:id="@+id/img_profile_link"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_link"
-        android:layout_marginTop="21dp"
-        app:layout_constraintTop_toBottomOf="@id/img_profile_location"
-        app:layout_constraintStart_toStartOf="@+id/img_profile_location"/>
-
-    <TextView
-        android:id="@+id/text_profile_link"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:textSize="16sp"
-        android:textColor="@color/white"
-        android:layout_marginStart="16dp"
-        app:layout_constraintStart_toEndOf="@id/img_profile_link"
-        app:layout_constraintTop_toTopOf="@id/img_profile_link"
-        app:layout_constraintBottom_toBottomOf="@id/img_profile_link"
-        tools:text="http://medium.com/@sam"/>
-
-    <ImageView
-        android:id="@+id/img_profile_mail"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_mail"
-        android:layout_marginTop="21dp"
-        app:layout_constraintTop_toBottomOf="@id/img_profile_link"
-        app:layout_constraintStart_toStartOf="@+id/img_profile_link"/>
-
-    <TextView
-        android:id="@+id/text_profile_mail"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:textSize="16sp"
-        android:textColor="@color/white"
-        android:layout_marginStart="16dp"
-        app:layout_constraintStart_toEndOf="@id/img_profile_mail"
-        app:layout_constraintTop_toTopOf="@id/img_profile_mail"
-        app:layout_constraintBottom_toBottomOf="@id/img_profile_mail"
-        tools:text="sam@gmail.com"/>
-
-    <ImageView
-        android:id="@+id/img_profile_follower"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_user"
-        android:layout_marginTop="21dp"
-        app:layout_constraintTop_toBottomOf="@id/img_profile_mail"
-        app:layout_constraintStart_toStartOf="@+id/img_profile_mail"/>
-
-    <TextView
-        android:id="@+id/text_profile_follower"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:textSize="16sp"
-        android:textColor="@color/white"
-        android:layout_marginStart="16dp"
-        app:layout_constraintStart_toEndOf="@id/img_profile_follower"
-        app:layout_constraintTop_toTopOf="@id/img_profile_follower"
-        app:layout_constraintBottom_toBottomOf="@id/img_profile_follower"
-        tools:text="59 Followers and 6 Following"/>
+        <variable
+            name="vm"
+            type="com.example.android_repo_04.viewmodel.ProfileViewModel" />
+    </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_profile_inner_container"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="24dp"
-        android:padding="16dp"
-        android:layout_marginTop="24dp"
-        android:background="@drawable/background_round_navy"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/img_profile_follower">
+        android:id="@+id/layout_profile_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/background_gradient"
+        android:paddingHorizontal="16dp"
+        tools:context=".view.profile.ProfileActivity">
 
-        <View
-            android:id="@+id/view_profile_repository"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="@drawable/background_round_primary"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
-
-        <ImageView
-            android:id="@+id/img_profile_repository"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:src="@drawable/ic_repository"
-            app:layout_constraintStart_toStartOf="@id/view_profile_repository"
-            app:layout_constraintEnd_toEndOf="@id/view_profile_repository"
-            app:layout_constraintTop_toTopOf="@id/view_profile_repository"
-            app:layout_constraintBottom_toBottomOf="@id/view_profile_repository"/>
-
-        <TextView
-            android:id="@+id/text_profile_repository"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="16sp"
-            android:textColor="@color/white"
-            android:text="@string/profile_repository"
-            android:layout_marginStart="16dp"
-            app:layout_constraintStart_toEndOf="@id/view_profile_repository"
-            app:layout_constraintTop_toTopOf="@id/view_profile_repository"
-            app:layout_constraintBottom_toBottomOf="@id/view_profile_repository"/>
-
-        <TextView
-            android:id="@+id/text_profile_repository_count"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="16sp"
-            android:textColor="@color/white"
-            app:layout_constraintTop_toTopOf="@id/text_profile_repository"
-            app:layout_constraintBottom_toBottomOf="@id/text_profile_repository"
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/layout_profile_toolbar"
+            android:layout_width="0dp"
+            android:layout_height="?attr/actionBarSize"
+            app:contentInsetStart="0dp"
             app:layout_constraintEnd_toEndOf="parent"
-            tools:text="41"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/img_profile_back"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="@drawable/icon_ripple_effect"
+                android:padding="8dp"
+                android:src="@drawable/ic_back" />
+
+            <TextView
+                android:id="@+id/text_profile_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/profile_title"
+                android:textColor="@color/white"
+                android:textSize="16sp" />
+        </androidx.appcompat.widget.Toolbar>
+
+        <de.hdodenhof.circleimageview.CircleImageView
+            android:id="@+id/img_profile_profile"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="24dp"
+            android:background="@drawable/ic_user"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_profile_toolbar"
+            bind:profileImage="@{vm.user.avatar_url}" />
+
+        <TextView
+            android:id="@+id/text_profile_display_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@{vm.user.login}"
+            android:textColor="@color/white"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/img_profile_profile"
+            app:layout_constraintTop_toTopOf="@id/img_profile_profile"
+            tools:text="최광현" />
+
+        <TextView
+            android:id="@+id/text_profile_user_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{vm.user.name}"
+            android:textColor="@color/grey"
+            android:textSize="16sp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/text_profile_display_name"
+            app:layout_constraintTop_toBottomOf="@id/text_profile_display_name"
+            tools:text="kwangddang" />
+
+        <TextView
+            android:id="@+id/text_profile_bio"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/background_round_navy"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:paddingHorizontal="12dp"
+            android:text="@{vm.user.bio}"
+            android:textColor="@color/grey"
+            android:textSize="16sp"
+            app:layout_constraintStart_toStartOf="@id/text_profile_display_name"
+            app:layout_constraintTop_toBottomOf="@id/text_profile_user_name"
+            tools:text="Android Developer" />
 
         <View
-            android:id="@+id/view_profile_star"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
+            android:id="@+id/view_profile_divider"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
             android:layout_marginTop="16dp"
-            android:background="@drawable/background_round_primary"
+            android:background="@color/navy"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/view_profile_repository"/>
+            app:layout_constraintTop_toBottomOf="@id/text_profile_bio" />
 
         <ImageView
-            android:id="@+id/img_profile_star"
+            android:id="@+id/img_profile_location"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_star"
-            app:layout_constraintStart_toStartOf="@id/view_profile_star"
-            app:layout_constraintEnd_toEndOf="@id/view_profile_star"
-            app:layout_constraintTop_toTopOf="@id/view_profile_star"
-            app:layout_constraintBottom_toBottomOf="@id/view_profile_star"/>
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="18dp"
+            android:src="@drawable/ic_location"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/view_profile_divider" />
 
         <TextView
-            android:id="@+id/text_profile_star"
-            android:layout_width="wrap_content"
+            android:id="@+id/text_profile_location"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:textSize="16sp"
-            android:textColor="@color/white"
-            android:text="@string/profile_star"
             android:layout_marginStart="16dp"
-            app:layout_constraintStart_toEndOf="@id/view_profile_star"
-            app:layout_constraintTop_toTopOf="@id/view_profile_star"
-            app:layout_constraintBottom_toBottomOf="@id/view_profile_star"/>
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            app:layout_constraintBottom_toBottomOf="@id/img_profile_location"
+            app:layout_constraintStart_toEndOf="@id/img_profile_location"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/img_profile_location"
+            bind:locationText="@{vm.user.location}"
+            tools:text="Seoul, Korea" />
 
-        <TextView
-            android:id="@+id/text_profile_star_count"
+        <ImageView
+            android:id="@+id/img_profile_link"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="16sp"
+            android:layout_marginTop="21dp"
+            android:src="@drawable/ic_link"
+            app:layout_constraintStart_toStartOf="@+id/img_profile_location"
+            app:layout_constraintTop_toBottomOf="@id/img_profile_location" />
+
+        <TextView
+            android:id="@+id/text_profile_link"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
             android:textColor="@color/white"
-            app:layout_constraintTop_toTopOf="@id/text_profile_star"
-            app:layout_constraintBottom_toBottomOf="@id/text_profile_star"
+            android:textSize="16sp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            app:layout_constraintBottom_toBottomOf="@id/img_profile_link"
+            app:layout_constraintStart_toEndOf="@id/img_profile_link"
+            app:layout_constraintTop_toTopOf="@id/img_profile_link"
             app:layout_constraintEnd_toEndOf="parent"
-            tools:text="57"/>
+            bind:blogText="@{vm.user.blog}"
+            tools:text="http://medium.com/@sam" />
+
+        <ImageView
+            android:id="@+id/img_profile_mail"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="21dp"
+            android:src="@drawable/ic_mail"
+            app:layout_constraintStart_toStartOf="@+id/img_profile_link"
+            app:layout_constraintTop_toBottomOf="@id/img_profile_link" />
+
+        <TextView
+            android:id="@+id/text_profile_mail"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            app:layout_constraintBottom_toBottomOf="@id/img_profile_mail"
+            app:layout_constraintStart_toEndOf="@id/img_profile_mail"
+            app:layout_constraintTop_toTopOf="@id/img_profile_mail"
+            app:layout_constraintEnd_toEndOf="parent"
+            bind:mailText="@{vm.user.email}"
+            tools:text="sam@gmail.com" />
+
+        <ImageView
+            android:id="@+id/img_profile_follower"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="21dp"
+            android:src="@drawable/ic_user"
+            app:layout_constraintStart_toStartOf="@+id/img_profile_mail"
+            app:layout_constraintTop_toBottomOf="@id/img_profile_mail" />
+
+        <TextView
+            android:id="@+id/text_profile_follower_count"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:text="@{Integer.toString(vm.user.followers)}"
+            app:layout_constraintBottom_toBottomOf="@id/img_profile_follower"
+            app:layout_constraintStart_toEndOf="@id/img_profile_follower"
+            app:layout_constraintTop_toTopOf="@id/img_profile_follower"
+            tools:text="59" />
+
+        <TextView
+            android:id="@+id/text_profile_follower"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="@string/profile_follower"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="@id/img_profile_follower"
+            app:layout_constraintStart_toEndOf="@id/text_profile_follower_count"
+            app:layout_constraintTop_toTopOf="@id/img_profile_follower" />
+
+
+        <TextView
+            android:id="@+id/text_profile_point"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="4dp"
+            android:text="@string/profile_point"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="@id/img_profile_follower"
+            app:layout_constraintStart_toEndOf="@id/text_profile_follower"
+            app:layout_constraintTop_toTopOf="@id/img_profile_follower" />
+
+        <TextView
+            android:id="@+id/text_profile_following_count"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:text="@{Integer.toString(vm.user.following)}"
+            app:layout_constraintBottom_toBottomOf="@id/img_profile_follower"
+            app:layout_constraintStart_toEndOf="@id/text_profile_point"
+            app:layout_constraintTop_toTopOf="@id/img_profile_follower"
+            tools:text="6" />
+
+        <TextView
+            android:id="@+id/text_profile_following"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="@string/profile_following"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="@id/img_profile_follower"
+            app:layout_constraintStart_toEndOf="@id/text_profile_following_count"
+            app:layout_constraintTop_toTopOf="@id/img_profile_follower" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_profile_inner_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="8dp"
+            android:layout_marginTop="24dp"
+            android:background="@drawable/background_round_navy"
+            android:padding="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/img_profile_follower">
+
+            <View
+                android:id="@+id/view_profile_repository"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="@drawable/background_round_primary"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:id="@+id/img_profile_repository"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_repository"
+                app:layout_constraintBottom_toBottomOf="@id/view_profile_repository"
+                app:layout_constraintEnd_toEndOf="@id/view_profile_repository"
+                app:layout_constraintStart_toStartOf="@id/view_profile_repository"
+                app:layout_constraintTop_toTopOf="@id/view_profile_repository" />
+
+            <TextView
+                android:id="@+id/text_profile_repository"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="@string/profile_repository"
+                android:textColor="@color/white"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toBottomOf="@id/view_profile_repository"
+                app:layout_constraintStart_toEndOf="@id/view_profile_repository"
+                app:layout_constraintTop_toTopOf="@id/view_profile_repository" />
+
+            <TextView
+                android:id="@+id/text_profile_repository_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@{Integer.toString(vm.user.public_repos + vm.user.total_private_repos)}"
+                android:textColor="@color/white"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toBottomOf="@id/text_profile_repository"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/text_profile_repository"
+                tools:text="41" />
+
+            <View
+                android:id="@+id/view_profile_star"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginTop="16dp"
+                android:background="@drawable/background_round_primary"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/view_profile_repository" />
+
+            <ImageView
+                android:id="@+id/img_profile_star"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_star"
+                app:layout_constraintBottom_toBottomOf="@id/view_profile_star"
+                app:layout_constraintEnd_toEndOf="@id/view_profile_star"
+                app:layout_constraintStart_toStartOf="@id/view_profile_star"
+                app:layout_constraintTop_toTopOf="@id/view_profile_star" />
+
+            <TextView
+                android:id="@+id/text_profile_star"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="@string/profile_star"
+                android:textColor="@color/white"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toBottomOf="@id/view_profile_star"
+                app:layout_constraintStart_toEndOf="@id/view_profile_star"
+                app:layout_constraintTop_toTopOf="@id/view_profile_star" />
+
+            <TextView
+                android:id="@+id/text_profile_star_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@{Integer.toString(vm.star)}"
+                android:textColor="@color/white"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toBottomOf="@id/text_profile_star"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/text_profile_star"
+                tools:text="57" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,7 @@
     <string name="profile_repository">Repositories</string>
     <string name="profile_star">Starred</string>
     <string name="issue_filter">Filter</string>
+    <string name="profile_follower">Followers</string>
+    <string name="profile_point">・</string>
+    <string name="profile_following">Following</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         okhttp_version = "4.9.3"
         glide_version = "4.13.2"
         kotpref_version = "2.13.1"
+        circle_imageview_version = "3.1.0"
     }
 }
 


### PR DESCRIPTION
# CircleImageView
https://github.com/hdodenhof/CircleImageView
  
ImageView를 원형으로 표현할 수 있게 해주는 라이브러리입니다.
ImageView를 상속받았기 때문에 기존에 기능은 모두 사용할 수 있으며,
현재 프로젝트에 쓰이지는 않지만

![image](https://user-images.githubusercontent.com/77563227/178907983-c490fc30-6c65-4668-a81f-13f7b3537b38.png)

위처럼 테두리를 쉽게 만들어줄 수 있다는 장점이 있습니다.
  
원형 이미지가 필요할 때 유용하게 쓸 수 있을 것 같아요!
CustomView로 따로 구현해도 되겠지만... 이미 있는 라이브러리이니 한번 사용해보았습니다!

# Count
### Repository Count
User를 조회했을 때 전체 RepositoryCount를 반환해주는 부분은 없었습니다.
하지만 public_repos와 private_repos를 제공해주기 때문에
이 두 변수를 더하여 Repository의 개수를 구했습니다.
  
### Starred Count
이건 아예 없더라구요..
그래서 https://api.github.com/user/starred 로 데이터를 요청하였습니다.
요청했을 때 star의 개수만 리턴되는 것이 아니라 레포지토리의 상세한 정보까지 리턴이 되었습니다.
  
그래서 간단하게 star의 id만 저장한 후,
star list의 사이즈로 star의 개수를 저장하였습니다.

# DataBinding
위의 모든 과정은 DataBinding과 BindingAdapter로 진행하였으며,
추가로 메일, 위치 등 유저가 정보를 설정하지 않은 경우는 그에 맞는 텍스트를 표시하는 것으로 처리하였습니다.