### PR TITLE
[MERGE] [hotfix/issue5 to main] issue5,14 - 화면 회전 여부에 관계없이 Issue와 Notifications 초기화는 무조건 1번

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -21,12 +21,14 @@
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.25" />
         <entry key="app/src/main/res/layout/activity_profile.xml" value="0.22395833333333334" />
         <entry key="app/src/main/res/layout/activity_user.xml" value="0.2015625" />
-        <entry key="app/src/main/res/layout/fragment_issue.xml" value="0.3958333333333333" />
+        <entry key="app/src/main/res/layout/fragment_issue.xml" value="0.165" />
         <entry key="app/src/main/res/layout/fragment_login.xml" value="0.3958333333333333" />
         <entry key="app/src/main/res/layout/fragment_notification.xml" value="0.18795289855072464" />
         <entry key="app/src/main/res/layout/item_issue.xml" value="0.234375" />
         <entry key="app/src/main/res/layout/item_notification.xml" value="0.1" />
         <entry key="app/src/main/res/layout/item_spinner.xml" value="0.234375" />
+        <entry key="app/src/main/res/layout/spinner_content.xml" value="0.1890625" />
+        <entry key="app/src/main/res/layout/spinner_title.xml" value="0.1890625" />
       </map>
     </option>
   </component>

--- a/app/src/main/java/com/example/android_repo_04/api/GitHubApiRepository.kt
+++ b/app/src/main/java/com/example/android_repo_04/api/GitHubApiRepository.kt
@@ -39,7 +39,6 @@ class GitHubApiRepository {
 
     suspend fun requestNotifications(token: String, callback: (List<Notification>?) -> Unit) {
         val response = RetrofitFactory.createApiService()!!.requestNotifications(token = token)
-        println(response)
         if (response.isSuccessful) {
             callback(response.body()!!)
         } else {

--- a/app/src/main/java/com/example/android_repo_04/view/main/MainActivity.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/main/MainActivity.kt
@@ -71,14 +71,12 @@ class MainActivity : AppCompatActivity() {
         observeData()
         setOnClickListeners()
         initFragmentManager()
+        getIssues()
+        getNotifications()
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProvider(this,
-            CustomViewModelFactory(
-                GitHubApiRepository.getGitInstance()!!
-            )
-        )[MainViewModel::class.java]
+        viewModel = MainViewModel.getInstance(GitHubApiRepository.getGitInstance()!!)
     }
 
     private fun observeData() {
@@ -99,6 +97,16 @@ class MainActivity : AppCompatActivity() {
                 add(R.id.layout_main_fragment_container, issueFragment, "issue")
             }
         }
+    }
+
+    private fun getIssues() {
+        if (viewModel.issue.value == null)
+            viewModel.requestIssues("token ${UserToken.accessToken}", IssueFragment.OPEN)
+    }
+
+    private fun getNotifications() {
+        if (viewModel.notifications.value == null)
+            viewModel.requestNotifications("token ${UserToken.accessToken}")
     }
 
     private fun selectIssue(){

--- a/app/src/main/java/com/example/android_repo_04/view/main/issue/IssueFragment.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/main/issue/IssueFragment.kt
@@ -36,9 +36,9 @@ class IssueFragment: Fragment() {
 
     private val spinnerItemSelectedListener = object: AdapterView.OnItemSelectedListener{
         override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+            spinnerAdapter.selectedPosition = position
             if (viewModel.selectedIssue != position) {
                 viewModel.selectedIssue = position
-                spinnerAdapter.selectedPosition = position
                 getSelectedIssues(position)
             }
         }

--- a/app/src/main/java/com/example/android_repo_04/view/main/issue/IssueFragment.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/main/issue/IssueFragment.kt
@@ -37,8 +37,10 @@ class IssueFragment: Fragment() {
 
     private val spinnerItemSelectedListener = object: AdapterView.OnItemSelectedListener{
         override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-            getSelectedIssues(position)
-            spinnerAdapter.selectedPosition = position
+            if (viewModel.selectedIssue != position) {
+                viewModel.selectedIssue = position
+                getSelectedIssues(position)
+            }
         }
 
         override fun onNothingSelected(parent: AdapterView<*>?) {
@@ -70,13 +72,10 @@ class IssueFragment: Fragment() {
         setSpinnerClickListener()
         setOnClickListener()
         observeData()
-        getIssues(OPEN)
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProvider(requireActivity(),
-            CustomViewModelFactory(GitHubApiRepository.getGitInstance()!!)
-        )[MainViewModel::class.java]
+        viewModel = MainViewModel.getInstance(GitHubApiRepository.getGitInstance()!!)
     }
 
     private fun initRecyclerAdapter() {
@@ -92,7 +91,6 @@ class IssueFragment: Fragment() {
         binding.spinnerIssueOption.viewTreeObserver.addOnWindowFocusChangeListener(spinnerWindowFocusChangeListener)
     }
 
-
     private fun setOnClickListener() {
         binding.layoutIssueInnerContainer.setOnClickListener {
             binding.spinnerIssueOption.performClick()
@@ -103,17 +101,11 @@ class IssueFragment: Fragment() {
         viewModel.issue.observe(viewLifecycleOwner, issueObserver)
     }
 
-    private fun getIssues(state: String) {
-        viewModel.requestIssues("token ${UserToken.accessToken}", state)
-    }
-
     private fun getSelectedIssues(position: Int) {
-        if (spinnerAdapter.selectedPosition != position) {
-            when (position) {
-                0 -> getIssues(OPEN)
-                1 -> getIssues(CLOSED)
-                2 -> getIssues(ALL)
-            }
+        when (position) {
+            0 -> viewModel.requestIssues("token ${UserToken.accessToken}", OPEN)
+            1 -> viewModel.requestIssues("token ${UserToken.accessToken}", CLOSED)
+            2 -> viewModel.requestIssues("token ${UserToken.accessToken}", ALL)
         }
     }
 

--- a/app/src/main/java/com/example/android_repo_04/view/main/issue/IssueFragment.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/main/issue/IssueFragment.kt
@@ -39,6 +39,7 @@ class IssueFragment: Fragment() {
         override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
             if (viewModel.selectedIssue != position) {
                 viewModel.selectedIssue = position
+                spinnerAdapter.selectedPosition = position
                 getSelectedIssues(position)
             }
         }

--- a/app/src/main/java/com/example/android_repo_04/view/main/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/main/notification/NotificationFragment.kt
@@ -56,16 +56,11 @@ class NotificationFragment: Fragment(), NotificationSwipeListener {
         initViewModel()
         initAdapter()
         observeData()
-        getNotifications()
         setItemTouchHelper()
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProvider(requireActivity(),
-            CustomViewModelFactory(
-                GitHubApiRepository.getGitInstance()!!
-            )
-        )[MainViewModel::class.java]
+        viewModel = MainViewModel.getInstance(GitHubApiRepository.getGitInstance()!!)
     }
 
     private fun initAdapter() {

--- a/app/src/main/java/com/example/android_repo_04/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/android_repo_04/viewmodel/MainViewModel.kt
@@ -1,15 +1,22 @@
 package com.example.android_repo_04.viewmodel
 
+import androidx.annotation.MainThread
 import androidx.lifecycle.*
-import androidx.lifecycle.viewmodel.CreationExtras
 import com.example.android_repo_04.api.GitHubApiRepository
 import com.example.android_repo_04.data.dto.issue.Issue
 import com.example.android_repo_04.data.dto.notification.Notification
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class MainViewModel(private val gitHubApiRepository: GitHubApiRepository): ViewModel() {
+    companion object{
+        private lateinit var instance: MainViewModel
+
+        @MainThread
+        fun getInstance(gitHubApiRepository: GitHubApiRepository): MainViewModel {
+            instance = if(::instance.isInitialized) instance else MainViewModel(gitHubApiRepository)
+            return instance
+        }
+    }
 
     private var _position = MutableLiveData(0)
     val position: LiveData<Int> get() = _position
@@ -22,6 +29,8 @@ class MainViewModel(private val gitHubApiRepository: GitHubApiRepository): ViewM
 
     private val _issue = MutableLiveData<Issue>()
     val issue: LiveData<Issue> get() = _issue
+
+    var selectedIssue = 0
 
     fun changePosition(pos: Int) {
         _position.postValue(pos)
@@ -54,7 +63,7 @@ class MainViewModel(private val gitHubApiRepository: GitHubApiRepository): ViewM
         }
     }
 
-    fun requestIssues(token: String, state: String = "all", filter: String = "all"){
+    fun requestIssues(token: String, state: String = "all", filter: String = "all") {
         viewModelScope.launch {
             gitHubApiRepository.requestIssues(token, state, filter) {
                 if (it != null){


### PR DESCRIPTION
초기화 이후 Issue Spinner 에서 선택하는 경우를 제외하고는 API 요청을 하지 않도록 FIX 했습니다!
API 요청을 해야 하는 부분을 모두 Singleton Class 인 `MainViewModel`에게 위임하였습니다.