### PR TITLE
[MERGE] [feat/debounce to main] Debounce 구현

### DIFF
--- a/app/src/main/java/com/example/android_repo_04/utils/Debounce.kt
+++ b/app/src/main/java/com/example/android_repo_04/utils/Debounce.kt
@@ -1,0 +1,21 @@
+package com.example.android_repo_04.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+
+var job: Job? = null
+
+fun debounce(
+    time: Long,
+    scope: CoroutineScope,
+    callback: () -> Unit
+) {
+    job?.cancel()
+    job = scope.launch {
+        delay(time)
+        callback()
+    }
+}

--- a/app/src/main/java/com/example/android_repo_04/utils/Debounce.kt
+++ b/app/src/main/java/com/example/android_repo_04/utils/Debounce.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 
-var job: Job? = null
+private var job: Job? = null
 
 fun debounce(
     time: Long,

--- a/app/src/main/java/com/example/android_repo_04/view/search/SearchActivity.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/search/SearchActivity.kt
@@ -36,14 +36,16 @@ class SearchActivity : AppCompatActivity(), SearchRefreshListener {
             binding.progressSearchLoading.visibility = View.INVISIBLE
             showHintText()
         }
+        viewModel.change(500L) {
+            if (text.isNotEmpty() && text.isNotBlank()) {
+                showProgress()
+                getSearchItems(text)
+            }
+        }
     }
 
     private val searchAdapter: SearchAdapter by lazy {
         SearchAdapter(viewModel)
-    }
-
-    private val imgSearchClickListener: (View) -> Unit = {
-        getSearchItems(binding.editSearchSearch.text.toString())
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -55,7 +57,6 @@ class SearchActivity : AppCompatActivity(), SearchRefreshListener {
         initAdapter()
         setOnClickListeners()
         setRefreshListener()
-        setOnEditorListener()
         setOnScrollListener()
         observeData()
     }
@@ -76,7 +77,6 @@ class SearchActivity : AppCompatActivity(), SearchRefreshListener {
     }
 
     private fun setOnClickListeners() {
-        binding.imgSearchSearch.setOnClickListener(imgSearchClickListener)
         binding.imgSearchBack.setOnClickListener { onBackPressed() }
         binding.imgSearchCancel.setOnClickListener { binding.editSearchSearch.setText("") }
     }
@@ -84,16 +84,6 @@ class SearchActivity : AppCompatActivity(), SearchRefreshListener {
     private fun setRefreshListener() {
         binding.refreshSearch.setOnRefreshListener {
             getSearchItems(binding.editSearchSearch.text.toString())
-        }
-    }
-
-    private fun setOnEditorListener() {
-        binding.editSearchSearch.addTextChangedListener { editable ->
-            if (!editable.isNullOrEmpty())
-                viewModel.change(500L) {
-                    showProgress()
-                    getSearchItems(editable.toString())
-                }
         }
     }
 

--- a/app/src/main/java/com/example/android_repo_04/view/search/SearchActivity.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/search/SearchActivity.kt
@@ -1,11 +1,13 @@
 package com.example.android_repo_04.view.search
 
 import android.os.Bundle
+import android.text.Editable
 import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.ViewModelProvider
 import com.example.android_repo_04.R
 import com.example.android_repo_04.api.GitHubApiRepository
@@ -36,15 +38,6 @@ class SearchActivity : AppCompatActivity(), SearchRefreshListener {
         }
     }
 
-    private val editorActionListener: (TextView, Int, KeyEvent?) -> Boolean = { view, actionId, event ->
-        if(actionId == EditorInfo.IME_ACTION_DONE) {
-            showProgress()
-            getSearchItems(view.text.toString())
-            true
-        }
-        false
-    }
-
     private val searchAdapter: SearchAdapter by lazy {
         SearchAdapter(viewModel)
     }
@@ -62,7 +55,7 @@ class SearchActivity : AppCompatActivity(), SearchRefreshListener {
         initAdapter()
         setOnClickListeners()
         setRefreshListener()
-        setOnEditorActionListener()
+        setOnEditorListener()
         setOnScrollListener()
         observeData()
     }
@@ -94,8 +87,14 @@ class SearchActivity : AppCompatActivity(), SearchRefreshListener {
         }
     }
 
-    private fun setOnEditorActionListener() {
-        binding.editSearchSearch.setOnEditorActionListener(editorActionListener)
+    private fun setOnEditorListener() {
+        binding.editSearchSearch.addTextChangedListener { editable ->
+            if (!editable.isNullOrEmpty())
+                viewModel.change(500L) {
+                    showProgress()
+                    getSearchItems(editable.toString())
+                }
+        }
     }
 
     private fun setOnScrollListener() {

--- a/app/src/main/java/com/example/android_repo_04/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/example/android_repo_04/viewmodel/SearchViewModel.kt
@@ -7,6 +7,9 @@ import androidx.lifecycle.viewModelScope
 import com.example.android_repo_04.api.GitHubApiRepository
 import com.example.android_repo_04.data.dto.search.Search
 import com.example.android_repo_04.utils.DataResponse
+import com.example.android_repo_04.utils.debounce
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class SearchViewModel(private val repository: GitHubApiRepository): ViewModel() {
@@ -41,5 +44,9 @@ class SearchViewModel(private val repository: GitHubApiRepository): ViewModel() 
 
     fun clearItems() {
         _searchItems.postValue(Search(listOf(), 0))
+    }
+
+    fun change(time: Long, callback: () -> Unit) {
+        debounce(time, viewModelScope, callback)
     }
 }


### PR DESCRIPTION
## Coroutine Job
`Coroutine`의 `Job` 객체를 이용하면 원하는 CoroutineScope를 제어할 수 있습니다.
[https://thdev.tech/kotlin/2019/04/08/Init-Coroutines-Job/](https://thdev.tech/kotlin/2019/04/08/Init-Coroutines-Job/)
위의 글은 Coroutine의 Job 동작을 설명한 글입니다. 위를 참고하여,
1. 저희는 정적 변수 `job`에게 1개의 CoroutineScope를 제어하도록 유도합니다. (이때의 Scope는 `viewModelScope`)
2. 새로운 `job` 요청이 들어오면 실행중이던 `job`을 종료한 뒤 제어권을 새로 잡습니다.
3. 사용자가 text를 새롭게 입력할 때마다 갱신하여 위를 반복합니다.
4. 사용자가 입력을 멈추면 2번이 실행되지 않으니 가장 마지막 상태에서 `job`을 마저 실행합니다.
5. SearchActivity를 보게 되면 `job`을 실행함과 동시에 `if (text.isNotEmpty() && text.isNotBlank())` 체크를 하는데, 이것은 text가 비었을 때 job의 제어권은 재할당 하되, 아무런 작업도 하지 않아야 하므로 지정해주었습니다. (안그러면 job이 글자1개일때의 작업을 수행하게 되므로)