### PR TITLE
[MERGE] [hotfix/issue22 to main] issue22 - 에러 Response 처리

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".GitHubApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/android_repo_04/GitHubApplication.kt
+++ b/app/src/main/java/com/example/android_repo_04/GitHubApplication.kt
@@ -1,0 +1,15 @@
+package com.example.android_repo_04
+
+import android.app.Application
+
+class GitHubApplication: Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+    }
+
+    companion object {
+        lateinit var instance: GitHubApplication
+    }
+}

--- a/app/src/main/java/com/example/android_repo_04/utils/DataResponse.kt
+++ b/app/src/main/java/com/example/android_repo_04/utils/DataResponse.kt
@@ -2,6 +2,6 @@ package com.example.android_repo_04.utils
 
 sealed class DataResponse<T> {
     data class Success<T>(val data: T? = null): DataResponse<T>()
-    data class Error<T>(val errorCode: Int? = null): DataResponse<T>()
+    data class Error<T>(val errorCode: Int): DataResponse<T>()
 }
 

--- a/app/src/main/java/com/example/android_repo_04/utils/ToastCreator.kt
+++ b/app/src/main/java/com/example/android_repo_04/utils/ToastCreator.kt
@@ -1,0 +1,49 @@
+package com.example.android_repo_04.utils
+
+import android.content.Context
+import android.widget.Toast
+import com.example.android_repo_04.GitHubApplication
+import com.example.android_repo_04.R
+
+fun createToast(msg: String) {
+    Toast.makeText(GitHubApplication.instance, msg, Toast.LENGTH_LONG).show()
+}
+
+fun createTokenErrorToast() {
+    Toast.makeText(
+        GitHubApplication.instance,
+        GitHubApplication.instance.getString(R.string.toast_error_token),
+        Toast.LENGTH_LONG
+    ).show()
+}
+
+fun createErrorToast(errorCode: Int) {
+    if (errorCode < 500)
+        when (errorCode) {
+            400 -> Toast.makeText(
+                GitHubApplication.instance,
+                GitHubApplication.instance.getString(R.string.toast_error_400),
+                Toast.LENGTH_LONG
+            ).show()
+            403 -> Toast.makeText(
+                GitHubApplication.instance,
+                GitHubApplication.instance.getString(R.string.toast_error_403),
+                Toast.LENGTH_LONG
+            ).show()
+            422 -> Toast.makeText(
+                GitHubApplication.instance,
+                GitHubApplication.instance.getString(R.string.toast_error_422),
+                Toast.LENGTH_LONG
+            ).show()
+            else -> Toast.makeText(
+                GitHubApplication.instance,
+                "$errorCode ${GitHubApplication.instance.getString(R.string.toast_error)}",
+                Toast.LENGTH_LONG
+            ).show()
+        }
+    else Toast.makeText(
+        GitHubApplication.instance,
+        GitHubApplication.instance.getString(R.string.toast_error_500),
+        Toast.LENGTH_LONG
+    ).show()
+}

--- a/app/src/main/java/com/example/android_repo_04/view/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/login/LoginActivity.kt
@@ -26,7 +26,6 @@ class LoginActivity : AppCompatActivity() {
 
     private val tokenObserver: (String) -> Unit = { token ->
         if (token.length < 5 && token != "") {
-            Toast.makeText(this, getString(R.string.toast_error_token), Toast.LENGTH_SHORT).show()
             binding.apply {
                 progressLoginLogin.visibility = View.INVISIBLE
                 btnLoginLogin.visibility = View.VISIBLE

--- a/app/src/main/java/com/example/android_repo_04/view/main/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/example/android_repo_04/view/main/notification/NotificationFragment.kt
@@ -35,13 +35,9 @@ class NotificationFragment: Fragment(), NotificationSwipeListener {
     }
 
     private val readNotificationObserver: (Int) -> Unit = { position ->
-        if (position >= 0) {
-            val newList = notificationAdapter.currentList.toMutableList()
-            newList.removeAt(position)
-            notificationAdapter.submitList(newList)
-        } else {
-            Toast.makeText(context, requireContext().getString(R.string.toast_error_notification), Toast.LENGTH_SHORT).show()
-        }
+        val newList = notificationAdapter.currentList.toMutableList()
+        newList.removeAt(position)
+        notificationAdapter.submitList(newList)
     }
 
     private val notificationRefreshEventObserver: (Unit) -> Unit = { event ->

--- a/app/src/main/java/com/example/android_repo_04/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/android_repo_04/viewmodel/LoginViewModel.kt
@@ -6,9 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.android_repo_04.BuildConfig
 import com.example.android_repo_04.api.GitHubLoginRepository
-import com.example.android_repo_04.utils.DataResponse
-import com.example.android_repo_04.utils.Event
-import com.example.android_repo_04.utils.emit
+import com.example.android_repo_04.utils.*
 import kotlinx.coroutines.launch
 
 class LoginViewModel(private val gitHubLoginRepository: GitHubLoginRepository) : ViewModel() {
@@ -25,7 +23,7 @@ class LoginViewModel(private val gitHubLoginRepository: GitHubLoginRepository) :
                 if (response is DataResponse.Success) {
                     _token.postValue(response.data!!.accessToken)
                 } else if(response is DataResponse.Error) {
-                    _token.postValue(response.errorCode?.toString())
+                    createTokenErrorToast()
                 }
             }
         }

--- a/app/src/main/java/com/example/android_repo_04/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/android_repo_04/viewmodel/MainViewModel.kt
@@ -1,17 +1,17 @@
 package com.example.android_repo_04.viewmodel
 
+import android.content.Context
 import android.view.View
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.android_repo_04.R
 import com.example.android_repo_04.api.GitHubApiRepository
 import com.example.android_repo_04.data.dto.issue.Issue
 import com.example.android_repo_04.data.dto.notification.Notification
 import com.example.android_repo_04.data.dto.profile.User
-import com.example.android_repo_04.utils.DataResponse
-import com.example.android_repo_04.utils.Event
-import com.example.android_repo_04.utils.emit
+import com.example.android_repo_04.utils.*
 import kotlinx.coroutines.launch
 
 class MainViewModel(private val gitHubApiRepository: GitHubApiRepository): ViewModel() {
@@ -50,8 +50,8 @@ class MainViewModel(private val gitHubApiRepository: GitHubApiRepository): ViewM
             gitHubApiRepository.requestNotifications() { response ->
                 if (response is DataResponse.Success) {
                     _notifications.postValue(response.data?.toMutableList())
-                } else {
-                    //TODO 에러처리
+                } else if (response is DataResponse.Error) {
+                    createErrorToast(response.errorCode)
                 }
             }
         }
@@ -62,8 +62,8 @@ class MainViewModel(private val gitHubApiRepository: GitHubApiRepository): ViewM
             gitHubApiRepository.requestToReadNotification(notifications.value!![position].id) { response ->
                 if (response is DataResponse.Success) {
                     _readNotification.postValue(position)
-                } else {
-                    _readNotification.postValue(-1)
+                } else if (response is DataResponse.Error) {
+                    createErrorToast(response.errorCode)
                 }
             }
         }
@@ -74,8 +74,8 @@ class MainViewModel(private val gitHubApiRepository: GitHubApiRepository): ViewM
             gitHubApiRepository.requestIssues(state, filter) { response ->
                 if(response is DataResponse.Success) {
                     _issue.postValue(response.data?.toMutableList())
-                } else {
-                    //TODO 에러처리
+                } else if (response is DataResponse.Error) {
+                    createErrorToast(response.errorCode)
                 }
             }
         }
@@ -86,8 +86,8 @@ class MainViewModel(private val gitHubApiRepository: GitHubApiRepository): ViewM
             gitHubApiRepository.requestUser() { response ->
                 if(response is DataResponse.Success) {
                     user.postValue(response.data!!)
-                } else {
-                    //TODO 에러처리
+                } else if (response is DataResponse.Error) {
+                    createErrorToast(response.errorCode)
                 }
             }
         }
@@ -98,8 +98,8 @@ class MainViewModel(private val gitHubApiRepository: GitHubApiRepository): ViewM
             gitHubApiRepository.requestUserStarredCount { response ->
                 if(response is DataResponse.Success) {
                     starCount.postValue(response.data!!)
-                } else {
-
+                } else if (response is DataResponse.Error) {
+                    createErrorToast(response.errorCode)
                 }
             }
         }

--- a/app/src/main/java/com/example/android_repo_04/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/example/android_repo_04/viewmodel/SearchViewModel.kt
@@ -7,10 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.android_repo_04.api.GitHubApiRepository
 import com.example.android_repo_04.data.dto.search.Search
-import com.example.android_repo_04.utils.DataResponse
-import com.example.android_repo_04.utils.Event
-import com.example.android_repo_04.utils.debounce
-import com.example.android_repo_04.utils.emit
+import com.example.android_repo_04.utils.*
 import kotlinx.coroutines.launch
 
 class SearchViewModel(private val repository: GitHubApiRepository): ViewModel() {
@@ -43,7 +40,8 @@ class SearchViewModel(private val repository: GitHubApiRepository): ViewModel() 
                         }
                     }
                 } else if (response is DataResponse.Error) {
-
+                    createErrorToast(response.errorCode)
+                    clearItems()
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,8 +25,12 @@
     <string name="login_path_auth">authorize</string>
     <string name="login_query_scope">user,repo,notifications</string>
 
-    <string name="toast_error_token">앱의 상태 정보가 정확하지 않습니다. 개발자에게 문의 바랍니다.</string>
-    <string name="toast_error_notification">Notification을 읽는 데 실패하였습니다.</string>
+    <string name="toast_error_token">사용자의 토큰 정보가 정확하지 않습니다. 개발자에게 문의 바랍니다.</string>
+    <string name="toast_error_400">잘못된 요청 메시지가 수신되었습니다. 개발자에게 문의 바랍니다.</string>
+    <string name="toast_error_403">과도한 요청으로 서비스 사용이 거부되었습니다. 재로그인 후 다시 실행해주십시오.</string>
+    <string name="toast_error_422">처리할 수 없는 쿼리를 수신했습니다. 제한된 서비스 내에서 이용해주십시오.</string>
+    <string name="toast_error_500">GitHub 서버 문제로 정상 실행할 수 없습니다. 잠시 후 다시 시도해주십시오.</string>
+    <string name="toast_error"> Error :: 개발자에게 문의 바랍니다.</string>
 
     <string name="tag_issue_fragment">issue</string>
     <string name="tag_notification_fragment">notification</string>


### PR DESCRIPTION
## Context 호출의 중복
처음에는 `context`를 Toast 메시지 마다 다 설정해주었습니다. 그러다보니 ErrorCode를 파악하는 `ViewModel`에 모든 API 요청 함수마다 `context`를 받아와야 했습니다. (아니면 ViewModel 생성 시에 넘겨주거나)
해당 부분은 `Fragment` 및 `Listener` 까지 들어가게되면 2중으로 `context`를 넘겨줘야 했습니다.

Toast 메시지는 `ApplicationContext` 상에서 유지되어도 문제가 없다고 생각했기 때문에, 글로벌 클래스로 `Application`을 상속 받은 객체를 선언한 뒤 (예전 KotPref 구현 때 처럼) 해당 `Application`의 `Instance`를 유지하여 그것을 이용하도록 구현했습니다.

## 에러 처리 목록
token 에러, 403(ratelimit 제한), 422(page 한도 초과) 등 확인된 에러 위주로 처리하도록 구현했습니다.
각 에러 메시지는 `strings.xml` 파일에 저장해두었습니다.


확인해 보시고 코멘트 남겨주세요!